### PR TITLE
Improve status bar readability

### DIFF
--- a/ui/appwindow.slint
+++ b/ui/appwindow.slint
@@ -159,17 +159,23 @@ export component AppWindow inherits Window {
             }
         }
 
-        // "Status Bar"
+        // Status bar
         Rectangle {
-            background: Colors.grey;
-            height: 24px;
+            background: root.background;
+            border-color: Colors.grey;
+            border-width: 1px;
+            height: 28px;
             width: 100%;
             Text {
-                //x: 16px;
-                x: parent.width / 32;
-                y: parent.height / 4;
-                color: root.background;
+                x: 12px;
+                width: parent.width - 24px;
+                height: parent.height;
+                vertical-alignment: center;
+                horizontal-alignment: left;
                 text: root.status-text;
+                wrap: no-wrap;
+                overflow: elide;
+                font-weight: 600;
             }
         }
     }


### PR DESCRIPTION
## Summary
- adjust status bar styling to use window background with border instead of hard-coded grey
- allow text to use default theme color with padding, stronger weight, and elided overflow

## Rationale
Removes the fixed grey status bar and background-colored text that could clash with light/dark themes, making messages clearer across themes.

## Changes
- updated status bar rectangle to use window background plus border
- tweaked status text alignment, padding, weight, and overflow handling

## Test Plan
- not run (UI layout change only)

Fixes #38